### PR TITLE
Update Twitter handle @flutterio -> @FlutterDev in Gallery app

### DIFF
--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // Thanks for checking out Flutter!
-// Like what you see? Tweet us @flutterio
+// Like what you see? Tweet us @FlutterDev
 
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
The @flutterio account now just directs people to @FlutterDev:

https://twitter.com/flutterio